### PR TITLE
Don't apply asChild to expressions

### DIFF
--- a/hsx2hs.cabal
+++ b/hsx2hs.cabal
@@ -42,7 +42,7 @@ Library
                         mtl              >= 2.0  && < 2.4,
                         haskell-src-exts >= 1.18 && < 1.24,
                         haskell-src-meta >= 0.7  && < 0.9,
-                        template-haskell >= 2.7  && < 2.21,
+                        template-haskell >= 2.7  && < 2.22,
                         bytestring,
                         utf8-string      >= 0.3  && < 1.1
   Hs-Source-Dirs: 	src
@@ -70,7 +70,7 @@ Executable hsx2hs
                         mtl              >= 2.0  && < 2.4,
                         haskell-src-exts >= 1.18 && < 1.24,
                         haskell-src-meta >= 0.7  && < 0.9,
-                        template-haskell >= 2.7  && < 2.20,
+                        template-haskell >= 2.7  && < 2.22,
                         bytestring,
                         utf8-string      >= 0.3  && < 1.1
 

--- a/hsx2hs.cabal
+++ b/hsx2hs.cabal
@@ -42,7 +42,7 @@ Library
                         mtl              >= 2.0  && < 2.4,
                         haskell-src-exts >= 1.18 && < 1.24,
                         haskell-src-meta >= 0.7  && < 0.9,
-                        template-haskell >= 2.7  && < 2.20,
+                        template-haskell >= 2.7  && < 2.21,
                         bytestring,
                         utf8-string      >= 0.3  && < 1.1
   Hs-Source-Dirs: 	src

--- a/src/Language/Haskell/HSX/QQ.hs
+++ b/src/Language/Haskell/HSX/QQ.hs
@@ -73,5 +73,5 @@ allExtensions = map EnableExtension
     [RecursiveDo,ParallelListComp,MultiParamTypeClasses,FunctionalDependencies,RankNTypes,ExistentialQuantification,
      ScopedTypeVariables,ImplicitParams,FlexibleContexts,FlexibleInstances,EmptyDataDecls,KindSignatures,
      BangPatterns,TemplateHaskell,ForeignFunctionInterface,Arrows,Generics,NamedFieldPuns,PatternGuards,
-     MagicHash,TypeFamilies,StandaloneDeriving,TypeOperators,RecordWildCards,GADTs,UnboxedTuples,
+     MagicHash,TypeApplications,TypeFamilies,StandaloneDeriving,TypeOperators,RecordWildCards,GADTs,UnboxedTuples,
      PackageImports,QuasiQuotes,TransformListComp,ViewPatterns,XmlSyntax,RegularPatterns]

--- a/src/Language/Haskell/HSX/Transform.hs
+++ b/src/Language/Haskell/HSX/Transform.hs
@@ -296,7 +296,7 @@ transformExpM e = case e of
     -- Escaped expressions should be treated as just expressions.
     XExpTag _ e     -> do setXmlTransformed
                           e' <- transformExpM e
-                          return $ paren $ metaAsChild e'
+                          return $ paren e'
 
     -- Patterns as arguments to a lambda expression could be regular,
     -- but we cannot put the evaluation here since a lambda expression


### PR DESCRIPTION
Expressions inside of a tag get wrapped in two calls to asChild, leading to ambiguity about the middle type (think read . show). Expressions should return something that can be turned into child content if they are inside of an element.

Tested against example-dot-org as requested.